### PR TITLE
Remove cancel-in-progress as it doesn't work

### DIFF
--- a/.github/workflows/shared-workflow.yaml
+++ b/.github/workflows/shared-workflow.yaml
@@ -105,7 +105,6 @@ on:
         required: false
 concurrency:
   group: "publish-${{ inputs.repository-name }}"
-  cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Remove cancel-in-progress as it doesn't work. Only one job will be queued if in the same concurrency group as per github docs.