### PR TITLE
CE-529 Adding dependabot config to all cloud-engineering repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" 
+    schedule:
+       interval: "weekly"
+    target-branch: "dev"


### PR DESCRIPTION
CE-529 Adding dependabot config to all cloud-engineering repos